### PR TITLE
Update vm-deploy-portal.md

### DIFF
--- a/vm-deploy-portal.md
+++ b/vm-deploy-portal.md
@@ -14,11 +14,7 @@
 
 1. In the upper left corner of the Azure portal, click **Create a resource**.
 
-1. At the top of the **New** blade, in the **Search the Marketplace** text box, type **Windows Server 2016** and press **Enter**.
-
-1. On the **Everything** blade, in the search results, click **Windows Server 2016 Datacenter**.
-
-1. On the **Windows Server 2016 Datacenter** blade, click the **Create** button.
+1. In the **New** blade, at the top of the **Popular** blade, click **Windows Server 2016 Datacenter** and press **Enter**.
 
 1. On the **Basics** tab, perform the following tasks:
 
@@ -26,7 +22,7 @@
     
     - In the **Resource group** section, click **Create new**.
     
-      - In the text box, type **YOURNAME-RG**. Replace YOURNAME with the name the trainer has provided you. For example: Peter-RG.
+      - In the text box, type **YOURNAMERG**. Replace YOURNAME with the name the trainer has provided you. For example: PeterRG.
     
       - click **OK** to create the resource group.
       
@@ -62,11 +58,11 @@
     
     - On the **Create virtual network** blade, specify the following settings and click **OK**:
 
-        - In the **Name** text box, enter the value **YOURNAME-vnet**.
+        - In the **Name** text box, enter the value **YOURNAMEvnet**.
 
         - In the **Address range** text box, enter the value **10.3.0.0/16**.
 
-        - In the **Subnet name** text box, enter the value **subnet-0**.
+        - In the **Subnet name** text box, enter the value **subnet0**.
 
         - In the **Subnet address range** text box, enter the value **10.3.0.0/24**, and click **OK**.
 
@@ -98,14 +94,14 @@
     
 1. On the **Create a virtual machine** blade, review the settings of your new virtual machine and click the **Create** button.
 
-1. Wait for the deployment to complete before proceding to the next task.
+1. Wait for the deployment to complete before proceding to the next task. This will take 5-15 minutes.
 
 
 #### Task 3: Connect to an Azure VM running Windows via a public IP address
 
 1. In the Azure portal, navigate to the Resource Groups blade.
 
-1. Click the **YOURNAME-RG** resource group to open it's contents.
+1. Click the **YOURNAMERG** resource group to open it's contents.
 
 1. Click the **vm1** virtual machine.
 
@@ -122,7 +118,7 @@
 
 1. In the Azure portal, navigate to the Resource Groups blade.
 
-1. Click the **YOURNAME-RG** resource group to open it's contents.
+1. Click the **YOURNAMERG** resource group to open it's contents.
 
 1. Click the **Delete resource group** button.
 


### PR DESCRIPTION
Ik kan geen Windows Server 2016 Datacenter vinden in de search the marketplace results, omdat dit een instap oefening is, om het makkelijk te houden zou ik voor de eerste hit in popular gaan.
Het -  teken heb ik uit de resourcegroup benaming gehaald. Reden: dubbelklik selectie lukt dan in 1 keer (voor copy/paste) bij het verwijderen van de resourcegroup.